### PR TITLE
tests: add tests for all api clients

### DIFF
--- a/src/endpoints/CheckoutApiClient.test.ts
+++ b/src/endpoints/CheckoutApiClient.test.ts
@@ -220,9 +220,9 @@ describe('CheckoutApiClient', () => {
       await expect(() =>
         checkoutApiClient.updateCheckoutRequest('', 'commerceCaseId', 'checkoutId', payload),
       ).rejects.toThrow('Merchant ID is required');
-      await expect(() => checkoutApiClient.updateCheckoutRequest('merchantId', '', 'checkoutId', payload)).rejects.toThrow(
-        'Commerce Case ID is required',
-      );
+      await expect(() =>
+        checkoutApiClient.updateCheckoutRequest('merchantId', '', 'checkoutId', payload),
+      ).rejects.toThrow('Commerce Case ID is required');
       await expect(() =>
         checkoutApiClient.updateCheckoutRequest('merchantId', 'commerceCaseId', '', payload),
       ).rejects.toThrow('Checkout ID is required');

--- a/src/endpoints/CheckoutApiClient.test.ts
+++ b/src/endpoints/CheckoutApiClient.test.ts
@@ -72,11 +72,11 @@ describe('CheckoutApiClient', () => {
         expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
       }
     });
-    test('a required params is empty, throw an error', () => {
-      expect(() => checkoutApiClient.createCheckoutRequest('', 'commerceCaseId', {})).rejects.toThrow(
+    test('a required params is empty, throw an error', async () => {
+      await expect(() => checkoutApiClient.createCheckoutRequest('', 'commerceCaseId', {})).rejects.toThrow(
         'Merchant ID is required',
       );
-      expect(() => checkoutApiClient.createCheckoutRequest('merchantId', '', {})).rejects.toThrow(
+      await expect(() => checkoutApiClient.createCheckoutRequest('merchantId', '', {})).rejects.toThrow(
         'Commerce Case ID is required',
       );
     });
@@ -120,14 +120,14 @@ describe('CheckoutApiClient', () => {
         expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
       }
     });
-    test('a required params is empty, throw an error', () => {
-      expect(() => checkoutApiClient.getCheckoutRequest('', 'commerceCaseId', 'checkoutId')).rejects.toThrow(
+    test('a required params is empty, throw an error', async () => {
+      await expect(() => checkoutApiClient.getCheckoutRequest('', 'commerceCaseId', 'checkoutId')).rejects.toThrow(
         'Merchant ID is required',
       );
-      expect(() => checkoutApiClient.getCheckoutRequest('merchantId', '', 'checkoutId')).rejects.toThrow(
+      await expect(() => checkoutApiClient.getCheckoutRequest('merchantId', '', 'checkoutId')).rejects.toThrow(
         'Commerce Case ID is required',
       );
-      expect(() => checkoutApiClient.getCheckoutRequest('merchantId', 'commerceCaseId', '')).rejects.toThrow(
+      await expect(() => checkoutApiClient.getCheckoutRequest('merchantId', 'commerceCaseId', '')).rejects.toThrow(
         'Checkout ID is required',
       );
     });
@@ -179,8 +179,8 @@ describe('CheckoutApiClient', () => {
         expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
       }
     });
-    test('a required params is empty, throw an error', () => {
-      expect(() => checkoutApiClient.getCheckoutsRequest('')).rejects.toThrow('Merchant ID is required');
+    test('a required params is empty, throw an error', async () => {
+      await expect(() => checkoutApiClient.getCheckoutsRequest('')).rejects.toThrow('Merchant ID is required');
     });
   });
   describe('updateCheckoutRequest', async () => {
@@ -216,14 +216,14 @@ describe('CheckoutApiClient', () => {
         expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
       }
     });
-    test('a required params is empty, throw an error', () => {
-      expect(() =>
+    test('a required params is empty, throw an error', async () => {
+      await expect(() =>
         checkoutApiClient.updateCheckoutRequest('', 'commerceCaseId', 'checkoutId', payload),
       ).rejects.toThrow('Merchant ID is required');
-      expect(() => checkoutApiClient.updateCheckoutRequest('merchantId', '', 'checkoutId', payload)).rejects.toThrow(
+      await expect(() => checkoutApiClient.updateCheckoutRequest('merchantId', '', 'checkoutId', payload)).rejects.toThrow(
         'Commerce Case ID is required',
       );
-      expect(() =>
+      await expect(() =>
         checkoutApiClient.updateCheckoutRequest('merchantId', 'commerceCaseId', '', payload),
       ).rejects.toThrow('Checkout ID is required');
     });
@@ -258,14 +258,14 @@ describe('CheckoutApiClient', () => {
         expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
       }
     });
-    test('a required params is empty, throw an error', () => {
-      expect(() => checkoutApiClient.removeCheckoutRequest('', 'commerceCaseId', 'checkoutId')).rejects.toThrow(
+    test('a required params is empty, throw an error', async () => {
+      await expect(() => checkoutApiClient.removeCheckoutRequest('', 'commerceCaseId', 'checkoutId')).rejects.toThrow(
         'Merchant ID is required',
       );
-      expect(() => checkoutApiClient.removeCheckoutRequest('merchantId', '', 'checkoutId')).rejects.toThrow(
+      await expect(() => checkoutApiClient.removeCheckoutRequest('merchantId', '', 'checkoutId')).rejects.toThrow(
         'Commerce Case ID is required',
       );
-      expect(() => checkoutApiClient.removeCheckoutRequest('merchantId', 'commerceCaseId', '')).rejects.toThrow(
+      await expect(() => checkoutApiClient.removeCheckoutRequest('merchantId', 'commerceCaseId', '')).rejects.toThrow(
         'Checkout ID is required',
       );
     });

--- a/src/endpoints/CheckoutApiClient.ts
+++ b/src/endpoints/CheckoutApiClient.ts
@@ -10,7 +10,12 @@ import type {
 } from '../models/index.js';
 
 import { GetCheckoutsQuery } from '../queries/index.js';
-import { BaseApiClient, CHECKOUT_ID_REQUIRED_ERROR, COMMERCE_CASE_ID_REQUIRED_ERROR, MERCHANT_ID_REQUIRED_ERROR } from './BaseApiClient.js';
+import {
+  BaseApiClient,
+  CHECKOUT_ID_REQUIRED_ERROR,
+  COMMERCE_CASE_ID_REQUIRED_ERROR,
+  MERCHANT_ID_REQUIRED_ERROR,
+} from './BaseApiClient.js';
 
 export class CheckoutApiClient extends BaseApiClient {
   constructor(config: CommunicatorConfiguration) {

--- a/src/endpoints/CommerceCaseApiClient.test.ts
+++ b/src/endpoints/CommerceCaseApiClient.test.ts
@@ -90,8 +90,8 @@ describe('CheckoutApiClient', () => {
         expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
       }
     });
-    test('a required params is empty, throw an error', () => {
-      expect(() => commerceCaseApiClient.createCommerceCaseRequest('', {})).rejects.toThrow('Merchant ID is required');
+    test('a required params is empty, throw an error', async () => {
+      await expect(() => commerceCaseApiClient.createCommerceCaseRequest('', {})).rejects.toThrow('Merchant ID is required');
     });
   });
   describe('getCommerceCaseRequest', () => {
@@ -139,11 +139,11 @@ describe('CheckoutApiClient', () => {
         expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
       }
     });
-    test('a required params is empty, throw an error', () => {
-      expect(() => commerceCaseApiClient.getCommerceCaseRequest('', 'commerceCaseId')).rejects.toThrow(
+    test('a required params is empty, throw an error', async () => {
+      await expect(() => commerceCaseApiClient.getCommerceCaseRequest('', 'commerceCaseId')).rejects.toThrow(
         'Merchant ID is required',
       );
-      expect(() => commerceCaseApiClient.getCommerceCaseRequest('merchantId', '')).rejects.toThrow(
+      await expect(() => commerceCaseApiClient.getCommerceCaseRequest('merchantId', '')).rejects.toThrow(
         'Commerce Case ID is required',
       );
     });
@@ -194,8 +194,8 @@ describe('CheckoutApiClient', () => {
         expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
       }
     });
-    test('a required params is empty, throw an error', () => {
-      expect(() => commerceCaseApiClient.getCommerceCasesRequest('')).rejects.toThrow('Merchant ID is required');
+    test('a required params is empty, throw an error', async () => {
+      await expect(() => commerceCaseApiClient.getCommerceCasesRequest('')).rejects.toThrow('Merchant ID is required');
     });
   });
   describe('updateCommerceCaseRequest', () => {
@@ -229,11 +229,11 @@ describe('CheckoutApiClient', () => {
         expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
       }
     });
-    test('a required params is empty, throw an error', () => {
-      expect(() => commerceCaseApiClient.updateCommerceCaseRequest('', 'commerceCaseId', {})).rejects.toThrow(
+    test('a required params is empty, throw an error', async () => {
+      await expect(() => commerceCaseApiClient.updateCommerceCaseRequest('', 'commerceCaseId', {})).rejects.toThrow(
         'Merchant ID is required',
       );
-      expect(() => commerceCaseApiClient.updateCommerceCaseRequest('merchantId', '', {})).rejects.toThrow(
+      await expect(() => commerceCaseApiClient.updateCommerceCaseRequest('merchantId', '', {})).rejects.toThrow(
         'Commerce Case ID is required',
       );
     });

--- a/src/endpoints/CommerceCaseApiClient.test.ts
+++ b/src/endpoints/CommerceCaseApiClient.test.ts
@@ -91,7 +91,9 @@ describe('CheckoutApiClient', () => {
       }
     });
     test('a required params is empty, throw an error', async () => {
-      await expect(() => commerceCaseApiClient.createCommerceCaseRequest('', {})).rejects.toThrow('Merchant ID is required');
+      await expect(() => commerceCaseApiClient.createCommerceCaseRequest('', {})).rejects.toThrow(
+        'Merchant ID is required',
+      );
     });
   });
   describe('getCommerceCaseRequest', () => {

--- a/src/endpoints/OrderManagementCheckoutActionsApiClient.test.ts
+++ b/src/endpoints/OrderManagementCheckoutActionsApiClient.test.ts
@@ -1,0 +1,291 @@
+import fetch from 'node-fetch';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { CommunicatorConfiguration } from '../CommunicatorConfiguration.js';
+import {
+  CartItemStatus,
+  OrderType,
+  type DeliverRequest,
+  type DeliverResponse,
+  type ErrorResponse,
+  type OrderRequest,
+  type OrderResponse,
+  type ReturnResponse,
+  type ReturnRequest,
+  type CancelResponse,
+  type CancelRequest,
+  CancelType,
+} from '../models/index.js';
+import { createResponseMock, createEmptyErrorResponseMock } from '../testutils/mock-response.js';
+import { ApiErrorResponseException } from '../errors/ApiErrorResponseException.js';
+import { ApiResponseRetrievalException } from '../errors/ApiResponseRetrievalException.js';
+import { OrderManagementCheckoutActionsApiClient } from './OrderManagementCheckoutActionsApiClient.js';
+
+vi.mock('node-fetch', async importOriginal => {
+  return {
+    ...(await importOriginal<typeof import('node-fetch')>()),
+    default: vi.fn(),
+  };
+});
+
+const mockedFetch = vi.mocked(fetch, true);
+
+describe('CheckoutApiClient', () => {
+  let orderManagementCheckoutActionsApiClient: OrderManagementCheckoutActionsApiClient;
+
+  beforeEach(() => {
+    orderManagementCheckoutActionsApiClient = new OrderManagementCheckoutActionsApiClient(
+      new CommunicatorConfiguration('apiKey', 'apiSecret', 'https://test.com'),
+    );
+  });
+
+  describe('createOrder', () => {
+    test('given request was successful, then return response', async () => {
+      const expectedResponse: OrderResponse = {
+        createPaymentResponse: {
+          paymentExecutionId: 'paymentExecutionId',
+        },
+      };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<OrderResponse>(200, expectedResponse));
+
+      const payload: OrderRequest = {
+        orderType: OrderType.Full,
+        items: [
+          { id: '1', quantity: 2 },
+          { id: '3', quantity: 1 },
+        ],
+      };
+      const res = await orderManagementCheckoutActionsApiClient.createOrder(
+        'merchantId',
+        'commerceCaseId',
+        'checkoutId',
+        payload,
+      );
+      expect(res).toEqual(expectedResponse);
+    });
+    test('given request was not successful (400), then return errorresponse', async () => {
+      const expectedResponse: ErrorResponse = { errorId: 'error-id' };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<ErrorResponse>(400, expectedResponse));
+
+      expect.assertions(1);
+      try {
+        await orderManagementCheckoutActionsApiClient.createOrder('merchantId', 'commerceCaseId', 'checkoutId', {});
+      } catch (error) {
+        expect(error).toEqual(new ApiErrorResponseException(400, JSON.stringify(expectedResponse)));
+      }
+    });
+    test('given request was not successful (500), throw ApiResponseRetrievalException', async () => {
+      mockedFetch.mockResolvedValueOnce(createEmptyErrorResponseMock(500));
+
+      expect.assertions(1);
+      try {
+        await orderManagementCheckoutActionsApiClient.createOrder('merchantId', 'commerceCaseId', 'checkoutId', {});
+      } catch (error) {
+        expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
+      }
+    });
+    test('a required params is empty, throw an error', async () => {
+      await expect(() =>
+        orderManagementCheckoutActionsApiClient.createOrder('', 'commerceCaseId', 'checkoutId', {}),
+      ).rejects.toThrow('Merchant ID is required');
+      await expect(() =>
+        orderManagementCheckoutActionsApiClient.createOrder('merchantId', '', 'checkoutId', {}),
+      ).rejects.toThrow('Commerce Case ID is required');
+      await expect(() =>
+        orderManagementCheckoutActionsApiClient.createOrder('merchantId', 'commerceCaseId', '', {}),
+      ).rejects.toThrow('Checkout ID is required');
+    });
+  });
+  describe('deliverOrder', () => {
+    const payload: DeliverRequest = {
+      isFinal: false,
+    };
+
+    test('given request was successful, then return response', async () => {
+      const expectedResponse: DeliverResponse = {
+        capturePaymentResponse: {},
+        shoppingCart: {
+          items: [
+            {
+              invoiceData: { description: 'some nice thing' },
+              orderLineDetails: {
+                id: 'abc',
+                status: [{ cartItemStatus: CartItemStatus.RETURNED, quantity: 1 }],
+                productPrice: 1459,
+                quantity: 1,
+              },
+            },
+          ],
+        },
+      };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<DeliverResponse>(200, expectedResponse));
+
+      const res = await orderManagementCheckoutActionsApiClient.deliverOrder(
+        'merchantId',
+        'commerceCaseId',
+        'checkoutId',
+        payload,
+      );
+      expect(res).toEqual(expectedResponse);
+    });
+    test('given request was not successful (400), then return errorresponse', async () => {
+      const expectedResponse: ErrorResponse = { errorId: 'error-id' };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<ErrorResponse>(400, expectedResponse));
+
+      expect.assertions(1);
+      try {
+        await orderManagementCheckoutActionsApiClient.deliverOrder(
+          'merchantId',
+          'commerceCaseId',
+          'checkoutId',
+          payload,
+        );
+      } catch (error) {
+        expect(error).toEqual(new ApiErrorResponseException(400, JSON.stringify(expectedResponse)));
+      }
+    });
+    test('given request was not successful (500), then return errorresponse', async () => {
+      mockedFetch.mockResolvedValueOnce(createEmptyErrorResponseMock(500));
+
+      expect.assertions(1);
+      try {
+        await orderManagementCheckoutActionsApiClient.deliverOrder(
+          'merchantId',
+          'commerceCaseId',
+          'checkoutId',
+          payload,
+        );
+      } catch (error) {
+        expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
+      }
+    });
+    test('a required param is empty, throw an error', async () => {
+      await expect(() =>
+        orderManagementCheckoutActionsApiClient.deliverOrder('', 'commerceCaseId', 'checkoutId', payload),
+      ).rejects.toThrowError('Merchant ID is required');
+      await expect(() =>
+        orderManagementCheckoutActionsApiClient.deliverOrder('merchantId', '', 'checkoutId', payload),
+      ).rejects.toThrowError('Commerce Case ID is required');
+      await expect(() =>
+        orderManagementCheckoutActionsApiClient.deliverOrder('merchantId', 'commerceCaseId', '', payload),
+      ).rejects.toThrowError('Checkout ID is required');
+    });
+  });
+  describe('returnOrder', () => {
+    test('given request was successful, then return response', async () => {
+      const expectedResponse: ReturnResponse = {
+        returnPaymentResponse: {
+          refundOutput: {
+            amountOfMoney: { amount: 1199, currencyCode: 'EUR' },
+            paymentMethod: 'cash',
+          },
+        },
+      };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<ReturnResponse>(200, expectedResponse));
+      const payload: ReturnRequest = {
+        returnReason: 'not needed',
+      };
+
+      const res = await orderManagementCheckoutActionsApiClient.returnOrder(
+        'merchantId',
+        'commerceCaseId',
+        'checkoutId',
+        payload,
+      );
+      expect(res).toEqual(expectedResponse);
+    });
+    test('given request was not successful (400), then return errorresponse', async () => {
+      const expectedResponse: ErrorResponse = { errorId: 'error-id' };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<ErrorResponse>(400, expectedResponse));
+
+      expect.assertions(1);
+      try {
+        await orderManagementCheckoutActionsApiClient.returnOrder('merchantId', 'commerceCaseId', 'checkoutId', {});
+      } catch (error) {
+        expect(error).toEqual(new ApiErrorResponseException(400, JSON.stringify(expectedResponse)));
+      }
+    });
+    test('given request was not successful (500), then return errorresponse', async () => {
+      mockedFetch.mockResolvedValueOnce(createEmptyErrorResponseMock(500));
+
+      expect.assertions(1);
+      try {
+        await orderManagementCheckoutActionsApiClient.returnOrder('merchantId', 'commerceCaseId', 'checkoutId', {});
+      } catch (error) {
+        expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
+      }
+    });
+    test('a required param is empty, throw an error', async () => {
+      await expect(() =>
+        orderManagementCheckoutActionsApiClient.returnOrder('', 'commerceCaseId', 'checkoutId', {}),
+      ).rejects.toThrowError('Merchant ID is required');
+      await expect(() =>
+        orderManagementCheckoutActionsApiClient.returnOrder('merchantId', '', 'checkoutId', {}),
+      ).rejects.toThrowError('Commerce Case ID is required');
+      await expect(() =>
+        orderManagementCheckoutActionsApiClient.returnOrder('merchantId', 'commerceCaseId', '', {}),
+      ).rejects.toThrowError('Checkout ID is required');
+    });
+  });
+  describe('cancelOrder', () => {
+    test('given request was successful, then return response', async () => {
+      const expectedResponse: CancelResponse = {
+        cancelPaymentResponse: {
+          payment: {
+            id: 'payed-id',
+          },
+        },
+      };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<CancelResponse>(200, expectedResponse));
+      const payload: CancelRequest = {
+        cancelType: CancelType.FULL,
+      };
+      const res = await orderManagementCheckoutActionsApiClient.cancelOrder(
+        'merchantId',
+        'commerceCaseId',
+        'checkoutId',
+        payload,
+      );
+      expect(res).toEqual(expectedResponse);
+    });
+    test('given request was not successful (400), then return errorresponse', async () => {
+      const expectedResponse: ErrorResponse = { errorId: 'error-id' };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<ErrorResponse>(400, expectedResponse));
+
+      expect.assertions(1);
+      try {
+        await orderManagementCheckoutActionsApiClient.cancelOrder('merchantId', 'commerceCaseId', 'checkoutId', {});
+      } catch (error) {
+        expect(error).toEqual(new ApiErrorResponseException(400, JSON.stringify(expectedResponse)));
+      }
+    });
+    test('given request was not successful (500), then return errorresponse', async () => {
+      mockedFetch.mockResolvedValueOnce(createEmptyErrorResponseMock(500));
+
+      expect.assertions(1);
+      try {
+        await orderManagementCheckoutActionsApiClient.cancelOrder('merchantId', 'commerceCaseId', 'checkoutId', {});
+      } catch (error) {
+        expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
+      }
+    });
+    test('a required param is empty, throw an error', async () => {
+      await expect(() =>
+        orderManagementCheckoutActionsApiClient.cancelOrder('', 'commerceCaseId', 'checkoutId', {}),
+      ).rejects.toThrowError('Merchant ID is required');
+      await expect(() =>
+        orderManagementCheckoutActionsApiClient.cancelOrder('merchantId', '', 'checkoutId', {}),
+      ).rejects.toThrowError('Commerce Case ID is required');
+      await expect(() =>
+        orderManagementCheckoutActionsApiClient.cancelOrder('merchantId', 'commerceCaseId', '', {}),
+      ).rejects.toThrowError('Checkout ID is required');
+    });
+  });
+});

--- a/src/endpoints/OrderManagementCheckoutActionsApiClient.ts
+++ b/src/endpoints/OrderManagementCheckoutActionsApiClient.ts
@@ -10,7 +10,12 @@ import type {
   ReturnRequest,
   ReturnResponse,
 } from '../models/index.js';
-import { BaseApiClient, CHECKOUT_ID_REQUIRED_ERROR, COMMERCE_CASE_ID_REQUIRED_ERROR, MERCHANT_ID_REQUIRED_ERROR } from './BaseApiClient.js';
+import {
+  BaseApiClient,
+  CHECKOUT_ID_REQUIRED_ERROR,
+  COMMERCE_CASE_ID_REQUIRED_ERROR,
+  MERCHANT_ID_REQUIRED_ERROR,
+} from './BaseApiClient.js';
 
 export class OrderManagementCheckoutActionsApiClient extends BaseApiClient {
   constructor(config: CommunicatorConfiguration) {

--- a/src/endpoints/PaymentExecutionApiClient.test.ts
+++ b/src/endpoints/PaymentExecutionApiClient.test.ts
@@ -1,0 +1,354 @@
+import fetch from 'node-fetch';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { CommunicatorConfiguration } from '../CommunicatorConfiguration.js';
+import {
+  CancellationReason,
+  StatusValue,
+  type CancelPaymentRequest,
+  type CancelPaymentResponse,
+  type CapturePaymentRequest,
+  type CapturePaymentResponse,
+  type CompletePaymentRequest,
+  type CompletePaymentResponse,
+  type CreatePaymentResponse,
+  type ErrorResponse,
+  type PaymentExecutionRequest,
+  type RefundPaymentResponse,
+  type RefundRequest,
+} from '../models/index.js';
+import { createResponseMock, createEmptyErrorResponseMock } from '../testutils/mock-response.js';
+import { ApiErrorResponseException } from '../errors/ApiErrorResponseException.js';
+import { ApiResponseRetrievalException } from '../errors/ApiResponseRetrievalException.js';
+import { PaymentExecutionApiClient } from './PaymentExecutionApiClient.js';
+
+vi.mock('node-fetch', async importOriginal => {
+  return {
+    ...(await importOriginal<typeof import('node-fetch')>()),
+    default: vi.fn(),
+  };
+});
+
+const mockedFetch = vi.mocked(fetch, true);
+
+describe('PaymentExecutionApiClient', () => {
+  let paymentExecutionApiClient: PaymentExecutionApiClient;
+
+  beforeEach(() => {
+    paymentExecutionApiClient = new PaymentExecutionApiClient(
+      new CommunicatorConfiguration('apiKey', 'apiSecret', 'https://test.com'),
+    );
+  });
+
+  describe('createPayment', () => {
+    test('given request was successful, should return response', async () => {
+      const expectedResponse: CreatePaymentResponse = {};
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<CreatePaymentResponse>(200, expectedResponse));
+
+      const payload: PaymentExecutionRequest = {
+        paymentExecutionSpecificInput: {
+          paymentReferences: { merchantReference: 'invoice-123' },
+          amountOfMoney: { amount: 3720, currencyCode: 'EUR' },
+        },
+      };
+      const res = await paymentExecutionApiClient.createPayment('merchantId', 'commerceCaseId', 'checkoutId', payload);
+
+      expect(res).toEqual(expectedResponse);
+    });
+    test('given request was not successful (400), then return errorresponse', async () => {
+      const expectedResponse: ErrorResponse = { errorId: 'error-id' };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<ErrorResponse>(400, expectedResponse));
+
+      expect.assertions(1);
+      try {
+        await paymentExecutionApiClient.createPayment('merchantId', 'commerceCaseId', 'checkoutId', {});
+      } catch (error) {
+        expect(error).toEqual(new ApiErrorResponseException(400, JSON.stringify(expectedResponse)));
+      }
+    });
+    test('given request was not successful (500), throw ApiResponseRetrievalException', async () => {
+      mockedFetch.mockResolvedValueOnce(createEmptyErrorResponseMock(500));
+
+      expect.assertions(1);
+      try {
+        await paymentExecutionApiClient.createPayment('merchantId', 'commerceCaseId', 'checkoutId', {});
+      } catch (error) {
+        expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
+      }
+    });
+    test('a required param is empty, throw an error', () => {
+      expect(() =>
+        paymentExecutionApiClient.createPayment('', 'commerceCaseId', 'checkoutId', {}),
+      ).rejects.toThrowError('Merchant ID is required');
+      expect(() => paymentExecutionApiClient.createPayment('merchantId', '', 'checkoutId', {})).rejects.toThrowError(
+        'Commerce Case ID is required',
+      );
+      expect(() =>
+        paymentExecutionApiClient.createPayment('merchantId', 'commerceCaseId', '', {}),
+      ).rejects.toThrowError('Checkout ID is required');
+    });
+  });
+  describe('capturePayment', () => {
+    test('given request was successful, should return response', async () => {
+      const expectedResponse: CapturePaymentResponse = {};
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<CapturePaymentResponse>(200, expectedResponse));
+
+      const payload: CapturePaymentRequest = {
+        isFinal: true,
+        delivery: {
+          items: [],
+        },
+      };
+      const res = await paymentExecutionApiClient.capturePayment(
+        'merchantId',
+        'commerceCaseId',
+        'checkoutId',
+        'paymentId',
+        payload,
+      );
+
+      expect(res).toEqual(expectedResponse);
+    });
+    test('given request was not successful (400), then return errorresponse', async () => {
+      const expectedResponse: ErrorResponse = { errorId: 'error-id' };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<ErrorResponse>(400, expectedResponse));
+
+      expect.assertions(1);
+      try {
+        await paymentExecutionApiClient.capturePayment('merchantId', 'commerceCaseId', 'checkoutId', 'paymentId', {
+          isFinal: false,
+        });
+      } catch (error) {
+        expect(error).toEqual(new ApiErrorResponseException(400, JSON.stringify(expectedResponse)));
+      }
+    });
+    test('given request was not successful (500), throw ApiResponseRetrievalException', async () => {
+      mockedFetch.mockResolvedValueOnce(createEmptyErrorResponseMock(500));
+
+      expect.assertions(1);
+      try {
+        await paymentExecutionApiClient.capturePayment('merchantId', 'commerceCaseId', 'checkoutId', 'paymentId', {
+          isFinal: false,
+        });
+      } catch (error) {
+        expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
+      }
+    });
+    test('a required param is empty, throw an error', () => {
+      expect(() =>
+        paymentExecutionApiClient.capturePayment('', 'commerceCaseId', 'checkoutId', 'paymentId', { isFinal: false }),
+      ).rejects.toThrowError('Merchant ID is required');
+      expect(() =>
+        paymentExecutionApiClient.capturePayment('merchantId', '', 'checkoutId', 'paymentId', { isFinal: false }),
+      ).rejects.toThrowError('Commerce Case ID is required');
+      expect(() =>
+        paymentExecutionApiClient.capturePayment('merchantId', 'commerceCaseId', '', 'paymentId', { isFinal: false }),
+      ).rejects.toThrowError('Checkout ID is required');
+      expect(() =>
+        paymentExecutionApiClient.capturePayment('merchantId', 'commerceCaseId', 'checkoutId', '', { isFinal: false }),
+      ).rejects.toThrowError('Payment Execution ID is required');
+    });
+  });
+  describe('cancelPayment', () => {
+    test('given request was successful, should return response', async () => {
+      const expectedResponse: CancelPaymentResponse = {
+        payment: {
+          status: StatusValue.Cancelled,
+          statusOutput: {
+            isCancellable: false,
+            isRefundable: false,
+          },
+        },
+      };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<CancelPaymentResponse>(200, expectedResponse));
+
+      const payload: CancelPaymentRequest = {
+        cancellationReason: CancellationReason.CONSUMER_REQUEST,
+      };
+      const res = await paymentExecutionApiClient.cancelPayment(
+        'merchantId',
+        'commerceCaseId',
+        'checkoutId',
+        'paymentId',
+        payload,
+      );
+      expect(res).toEqual(expectedResponse);
+    });
+    test('given request was not successful (400), then return errorresponse', async () => {
+      const expectedResponse: ErrorResponse = { errorId: 'error-id' };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<ErrorResponse>(400, expectedResponse));
+
+      expect.assertions(1);
+      try {
+        await paymentExecutionApiClient.cancelPayment('merchantId', 'commerceCaseId', 'checkoutId', 'paymentId', {});
+      } catch (error) {
+        expect(error).toEqual(new ApiErrorResponseException(400, JSON.stringify(expectedResponse)));
+      }
+    });
+    test('given request was not successful (500), throw ApiResponseRetrievalException', async () => {
+      mockedFetch.mockResolvedValueOnce(createEmptyErrorResponseMock(500));
+
+      expect.assertions(1);
+      try {
+        await paymentExecutionApiClient.cancelPayment('merchantId', 'commerceCaseId', 'checkoutId', 'paymentId', {});
+      } catch (error) {
+        expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
+      }
+    });
+    test('a required param is empty, throw an error', () => {
+      expect(() =>
+        paymentExecutionApiClient.cancelPayment('', 'commerceCaseId', 'checkoutId', 'paymentId', {}),
+      ).rejects.toThrowError('Merchant ID is required');
+      expect(() =>
+        paymentExecutionApiClient.cancelPayment('merchantId', '', 'checkoutId', 'paymentId', {}),
+      ).rejects.toThrowError('Commerce Case ID is required');
+      expect(() =>
+        paymentExecutionApiClient.cancelPayment('merchantId', 'commerceCaseId', '', 'paymentId', {}),
+      ).rejects.toThrowError('Checkout ID is required');
+      expect(() =>
+        paymentExecutionApiClient.cancelPayment('merchantId', 'commerceCaseId', 'checkoutId', '', {}),
+      ).rejects.toThrowError('Payment Execution ID is required');
+    });
+  });
+  describe('refundPayment', () => {
+    test('given request was successful, should return response', async () => {
+      const expectedResponse: RefundPaymentResponse = {
+        status: StatusValue.Refunded,
+        statusOutput: {
+          isCancellable: false,
+          isRefundable: false,
+          isAuthorized: true,
+        },
+      };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<RefundPaymentResponse>(200, expectedResponse));
+
+      const payload: RefundRequest = {
+        return: {
+          returnReason: 'Customer unhappy',
+        },
+      };
+      const res = await paymentExecutionApiClient.refundPayment(
+        'merchantId',
+        'commerceCaseId',
+        'checkoutId',
+        'paymentId',
+        payload,
+      );
+      expect(res).toEqual(expectedResponse);
+    });
+    test('given request was not successful (400), then return errorresponse', async () => {
+      const expectedResponse: ErrorResponse = { errorId: 'error-id' };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<ErrorResponse>(400, expectedResponse));
+
+      expect.assertions(1);
+      try {
+        await paymentExecutionApiClient.refundPayment('merchantId', 'commerceCaseId', 'checkoutId', 'paymentId', {});
+      } catch (error) {
+        expect(error).toEqual(new ApiErrorResponseException(400, JSON.stringify(expectedResponse)));
+      }
+    });
+    test('given request was not successful (500), throw ApiResponseRetrievalException', async () => {
+      mockedFetch.mockResolvedValueOnce(createEmptyErrorResponseMock(500));
+
+      expect.assertions(1);
+      try {
+        await paymentExecutionApiClient.refundPayment('merchantId', 'commerceCaseId', 'checkoutId', 'paymentId', {});
+      } catch (error) {
+        expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
+      }
+    });
+    test('a required param is empty, throw an error', () => {
+      expect(() =>
+        paymentExecutionApiClient.refundPayment('', 'commerceCaseId', 'checkoutId', 'paymentId', {}),
+      ).rejects.toThrowError('Merchant ID is required');
+      expect(() =>
+        paymentExecutionApiClient.refundPayment('merchantId', '', 'checkoutId', 'paymentId', {}),
+      ).rejects.toThrowError('Commerce Case ID is required');
+      expect(() =>
+        paymentExecutionApiClient.refundPayment('merchantId', 'commerceCaseId', '', 'paymentId', {}),
+      ).rejects.toThrowError('Checkout ID is required');
+      expect(() =>
+        paymentExecutionApiClient.refundPayment('merchantId', 'commerceCaseId', 'checkoutId', '', {}),
+      ).rejects.toThrowError('Payment Execution ID is required');
+    });
+  });
+  describe('completePayment', () => {
+    test('given request was successful, should return response', async () => {
+      const expectedResponse: CompletePaymentResponse = {
+        merchantAction: {
+          actionType: 'REDIRECT',
+          redirectData: {
+            redirectURL: 'https://redirect.com',
+          },
+        },
+      };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<CompletePaymentResponse>(200, expectedResponse));
+
+      const payload: CompletePaymentRequest = {
+        order: {
+          amountOfMoney: { amount: 3720, currencyCode: 'EUR' },
+          references: {
+            merchantReference: 'order-5001',
+          },
+        },
+        device: {
+          ipAddress: '0.0.0.0',
+          deviceToken: 'tokentokentoken',
+        },
+      };
+
+      const res = await paymentExecutionApiClient.completePayment(
+        'merchantId',
+        'commerceCaseId',
+        'checkoutId',
+        'paymentId',
+        payload,
+      );
+      expect(res).toEqual(expectedResponse);
+    });
+    test('given request was not successful (400), then return errorresponse', async () => {
+      const expectedResponse: ErrorResponse = { errorId: 'error-id' };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<ErrorResponse>(400, expectedResponse));
+
+      expect.assertions(1);
+      try {
+        await paymentExecutionApiClient.completePayment('merchantId', 'commerceCaseId', 'checkoutId', 'paymentId', {});
+      } catch (error) {
+        expect(error).toEqual(new ApiErrorResponseException(400, JSON.stringify(expectedResponse)));
+      }
+    });
+    test('given request was not successful (500), throw ApiResponseRetrievalException', async () => {
+      mockedFetch.mockResolvedValueOnce(createEmptyErrorResponseMock(500));
+
+      expect.assertions(1);
+      try {
+        await paymentExecutionApiClient.completePayment('merchantId', 'commerceCaseId', 'checkoutId', 'paymentId', {});
+      } catch (error) {
+        expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
+      }
+    });
+    test('a required param is empty, throw an error', () => {
+      expect(() =>
+        paymentExecutionApiClient.completePayment('', 'commerceCaseId', 'checkoutId', 'paymentId', {}),
+      ).rejects.toThrowError('Merchant ID is required');
+      expect(() =>
+        paymentExecutionApiClient.completePayment('merchantId', '', 'checkoutId', 'paymentId', {}),
+      ).rejects.toThrowError('Commerce Case ID is required');
+      expect(() =>
+        paymentExecutionApiClient.completePayment('merchantId', 'commerceCaseId', '', 'paymentId', {}),
+      ).rejects.toThrowError('Checkout ID is required');
+      expect(() =>
+        paymentExecutionApiClient.completePayment('merchantId', 'commerceCaseId', 'checkoutId', '', {}),
+      ).rejects.toThrowError('Payment Execution ID is required');
+    });
+  });
+});

--- a/src/endpoints/PaymentExecutionApiClient.test.ts
+++ b/src/endpoints/PaymentExecutionApiClient.test.ts
@@ -81,9 +81,9 @@ describe('PaymentExecutionApiClient', () => {
       await expect(() =>
         paymentExecutionApiClient.createPayment('', 'commerceCaseId', 'checkoutId', {}),
       ).rejects.toThrowError('Merchant ID is required');
-      await expect(() => paymentExecutionApiClient.createPayment('merchantId', '', 'checkoutId', {})).rejects.toThrowError(
-        'Commerce Case ID is required',
-      );
+      await expect(() =>
+        paymentExecutionApiClient.createPayment('merchantId', '', 'checkoutId', {}),
+      ).rejects.toThrowError('Commerce Case ID is required');
       await expect(() =>
         paymentExecutionApiClient.createPayment('merchantId', 'commerceCaseId', '', {}),
       ).rejects.toThrowError('Checkout ID is required');

--- a/src/endpoints/PaymentExecutionApiClient.test.ts
+++ b/src/endpoints/PaymentExecutionApiClient.test.ts
@@ -77,14 +77,14 @@ describe('PaymentExecutionApiClient', () => {
         expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
       }
     });
-    test('a required param is empty, throw an error', () => {
-      expect(() =>
+    test('a required param is empty, throw an error', async () => {
+      await expect(() =>
         paymentExecutionApiClient.createPayment('', 'commerceCaseId', 'checkoutId', {}),
       ).rejects.toThrowError('Merchant ID is required');
-      expect(() => paymentExecutionApiClient.createPayment('merchantId', '', 'checkoutId', {})).rejects.toThrowError(
+      await expect(() => paymentExecutionApiClient.createPayment('merchantId', '', 'checkoutId', {})).rejects.toThrowError(
         'Commerce Case ID is required',
       );
-      expect(() =>
+      await expect(() =>
         paymentExecutionApiClient.createPayment('merchantId', 'commerceCaseId', '', {}),
       ).rejects.toThrowError('Checkout ID is required');
     });
@@ -137,17 +137,17 @@ describe('PaymentExecutionApiClient', () => {
         expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
       }
     });
-    test('a required param is empty, throw an error', () => {
-      expect(() =>
+    test('a required param is empty, throw an error', async () => {
+      await expect(() =>
         paymentExecutionApiClient.capturePayment('', 'commerceCaseId', 'checkoutId', 'paymentId', { isFinal: false }),
       ).rejects.toThrowError('Merchant ID is required');
-      expect(() =>
+      await expect(() =>
         paymentExecutionApiClient.capturePayment('merchantId', '', 'checkoutId', 'paymentId', { isFinal: false }),
       ).rejects.toThrowError('Commerce Case ID is required');
-      expect(() =>
+      await expect(() =>
         paymentExecutionApiClient.capturePayment('merchantId', 'commerceCaseId', '', 'paymentId', { isFinal: false }),
       ).rejects.toThrowError('Checkout ID is required');
-      expect(() =>
+      await expect(() =>
         paymentExecutionApiClient.capturePayment('merchantId', 'commerceCaseId', 'checkoutId', '', { isFinal: false }),
       ).rejects.toThrowError('Payment Execution ID is required');
     });
@@ -200,17 +200,17 @@ describe('PaymentExecutionApiClient', () => {
         expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
       }
     });
-    test('a required param is empty, throw an error', () => {
-      expect(() =>
+    test('a required param is empty, throw an error', async () => {
+      await expect(() =>
         paymentExecutionApiClient.cancelPayment('', 'commerceCaseId', 'checkoutId', 'paymentId', {}),
       ).rejects.toThrowError('Merchant ID is required');
-      expect(() =>
+      await expect(() =>
         paymentExecutionApiClient.cancelPayment('merchantId', '', 'checkoutId', 'paymentId', {}),
       ).rejects.toThrowError('Commerce Case ID is required');
-      expect(() =>
+      await expect(() =>
         paymentExecutionApiClient.cancelPayment('merchantId', 'commerceCaseId', '', 'paymentId', {}),
       ).rejects.toThrowError('Checkout ID is required');
-      expect(() =>
+      await expect(() =>
         paymentExecutionApiClient.cancelPayment('merchantId', 'commerceCaseId', 'checkoutId', '', {}),
       ).rejects.toThrowError('Payment Execution ID is required');
     });
@@ -264,17 +264,17 @@ describe('PaymentExecutionApiClient', () => {
         expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
       }
     });
-    test('a required param is empty, throw an error', () => {
-      expect(() =>
+    test('a required param is empty, throw an error', async () => {
+      await expect(() =>
         paymentExecutionApiClient.refundPayment('', 'commerceCaseId', 'checkoutId', 'paymentId', {}),
       ).rejects.toThrowError('Merchant ID is required');
-      expect(() =>
+      await expect(() =>
         paymentExecutionApiClient.refundPayment('merchantId', '', 'checkoutId', 'paymentId', {}),
       ).rejects.toThrowError('Commerce Case ID is required');
-      expect(() =>
+      await expect(() =>
         paymentExecutionApiClient.refundPayment('merchantId', 'commerceCaseId', '', 'paymentId', {}),
       ).rejects.toThrowError('Checkout ID is required');
-      expect(() =>
+      await expect(() =>
         paymentExecutionApiClient.refundPayment('merchantId', 'commerceCaseId', 'checkoutId', '', {}),
       ).rejects.toThrowError('Payment Execution ID is required');
     });
@@ -336,17 +336,17 @@ describe('PaymentExecutionApiClient', () => {
         expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
       }
     });
-    test('a required param is empty, throw an error', () => {
-      expect(() =>
+    test('a required param is empty, throw an error', async () => {
+      await expect(() =>
         paymentExecutionApiClient.completePayment('', 'commerceCaseId', 'checkoutId', 'paymentId', {}),
       ).rejects.toThrowError('Merchant ID is required');
-      expect(() =>
+      await expect(() =>
         paymentExecutionApiClient.completePayment('merchantId', '', 'checkoutId', 'paymentId', {}),
       ).rejects.toThrowError('Commerce Case ID is required');
-      expect(() =>
+      await expect(() =>
         paymentExecutionApiClient.completePayment('merchantId', 'commerceCaseId', '', 'paymentId', {}),
       ).rejects.toThrowError('Checkout ID is required');
-      expect(() =>
+      await expect(() =>
         paymentExecutionApiClient.completePayment('merchantId', 'commerceCaseId', 'checkoutId', '', {}),
       ).rejects.toThrowError('Payment Execution ID is required');
     });

--- a/src/endpoints/PaymentInformationApiClient.test.ts
+++ b/src/endpoints/PaymentInformationApiClient.test.ts
@@ -1,0 +1,191 @@
+import fetch from 'node-fetch';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { CommunicatorConfiguration } from '../CommunicatorConfiguration.js';
+import {
+  CancellationReason,
+  PaymentChannel,
+  PaymentType,
+  StatusValue,
+  type CancelPaymentRequest,
+  type CancelPaymentResponse,
+  type CapturePaymentRequest,
+  type CapturePaymentResponse,
+  type CompletePaymentRequest,
+  type CompletePaymentResponse,
+  type CreatePaymentResponse,
+  type ErrorResponse,
+  type PaymentExecutionRequest,
+  type PaymentInformationRequest,
+  type PaymentInformationResponse,
+  type RefundPaymentResponse,
+  type RefundRequest,
+} from '../models/index.js';
+import { createResponseMock, createEmptyErrorResponseMock } from '../testutils/mock-response.js';
+import { ApiErrorResponseException } from '../errors/ApiErrorResponseException.js';
+import { ApiResponseRetrievalException } from '../errors/ApiResponseRetrievalException.js';
+import { PaymentInformationApiClient } from './PaymentInformationApiClient.js';
+
+vi.mock('node-fetch', async importOriginal => {
+  return {
+    ...(await importOriginal<typeof import('node-fetch')>()),
+    default: vi.fn(),
+  };
+});
+
+const mockedFetch = vi.mocked(fetch, true);
+
+describe('PaymentInformationApiClient', () => {
+  let paymentInformationApiClient: PaymentInformationApiClient;
+
+  beforeEach(() => {
+    paymentInformationApiClient = new PaymentInformationApiClient(
+      new CommunicatorConfiguration('apiKey', 'apiSecret', 'https://test.com'),
+    );
+  });
+
+  describe('createPaymentInformation', () => {
+    const payload: PaymentInformationRequest = {
+      amountOfMoney: {
+        amount: 1289,
+        currencyCode: 'EUR',
+      },
+      type: PaymentType.Sale,
+      paymentProductId: 1331,
+      paymentChannel: PaymentChannel.Ecommerce,
+    };
+
+    test('given request was successful, should return response', async () => {
+      const expectedResponse: PaymentInformationResponse = {
+        paymentChannel: PaymentChannel.Pos,
+        terminalId: 'terminalId',
+        cardPaymentDetails: {
+          maskedCardNumber: '672559XXXXXX1108',
+          paymentProcessingToken: '0ca037cc-9079-4df7-8f6f-f2a3443ee521',
+          reportingToken: '12a037cc-833d-8b45-8f6f-11c34171f4e1',
+          cardAuthorizationId: '260042',
+        },
+        events: [],
+      };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<PaymentInformationResponse>(200, expectedResponse));
+
+      const res = await paymentInformationApiClient.createPaymentInformation(
+        'merchantId',
+        'commerceCaseId',
+        'checkoutId',
+        payload,
+      );
+
+      expect(res).toEqual(expectedResponse);
+    });
+
+    test('given request was not successful (400), then return errorresponse', async () => {
+      const expectedResponse: ErrorResponse = { errorId: 'error-id' };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<ErrorResponse>(400, expectedResponse));
+
+      expect.assertions(1);
+      try {
+        await paymentInformationApiClient.createPaymentInformation(
+          'merchantId',
+          'commerceCaseId',
+          'checkoutId',
+          payload,
+        );
+      } catch (error) {
+        expect(error).toEqual(new ApiErrorResponseException(400, JSON.stringify(expectedResponse)));
+      }
+    });
+    test('given request was not successful (500), then return errorresponse', async () => {
+      mockedFetch.mockResolvedValueOnce(createEmptyErrorResponseMock(500));
+
+      expect.assertions(1);
+      try {
+        await paymentInformationApiClient.createPaymentInformation(
+          'merchantId',
+          'commerceCaseId',
+          'checkoutId',
+          payload,
+        );
+      } catch (error) {
+        expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
+      }
+    });
+    test('a required param is empty, throw an error', async () => {
+      await expect(() =>
+        paymentInformationApiClient.createPaymentInformation('', 'commerceCaseId', 'checkoutId', payload),
+      ).rejects.toThrowError('Merchant ID is required');
+      await expect(() =>
+        paymentInformationApiClient.createPaymentInformation('merchantId', '', 'checkoutId', payload),
+      ).rejects.toThrowError('Commerce Case ID is required');
+      await expect(() =>
+        paymentInformationApiClient.createPaymentInformation('merchantId', 'commerceCaseId', '', payload),
+      ).rejects.toThrowError('Checkout ID is required');
+    });
+  });
+  describe('getPaymentInformation', () => {
+    test('given request was successful, should return response', async () => {
+      const expectedResponse: PaymentInformationResponse = {
+        commerceCaseId: 'commerceCaseId',
+        checkoutId: 'checkoutId',
+        paymentProductId: 4040,
+      };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<PaymentInformationResponse>(200, expectedResponse));
+
+      const res = await paymentInformationApiClient.getPaymentInformation(
+        'merchantId',
+        'commerceCaseId',
+        'checkoutId',
+        'paymentInformationId',
+      );
+      expect(res).toEqual(expectedResponse);
+    });
+    test('given request was not successful (400), then return errorresponse', async () => {
+      const expectedResponse: ErrorResponse = { errorId: 'error-id' };
+
+      mockedFetch.mockResolvedValueOnce(createResponseMock<ErrorResponse>(400, expectedResponse));
+
+      expect.assertions(1);
+      try {
+        await paymentInformationApiClient.getPaymentInformation(
+          'merchantId',
+          'commerceCaseId',
+          'checkoutId',
+          'paymentInformationId',
+        );
+      } catch (error) {
+        expect(error).toEqual(new ApiErrorResponseException(400, JSON.stringify(expectedResponse)));
+      }
+    });
+    test('given request was not successful (500), then return errorresponse', async () => {
+      mockedFetch.mockResolvedValueOnce(createEmptyErrorResponseMock(500));
+
+      expect.assertions(1);
+      try {
+        await paymentInformationApiClient.getPaymentInformation(
+          'merchantId',
+          'commerceCaseId',
+          'checkoutId',
+          'paymentInformationId',
+        );
+      } catch (error) {
+        expect(error).toEqual(new ApiResponseRetrievalException(500, ''));
+      }
+    });
+    test('a required param is empty, throw an error', async () => {
+      await expect(() =>
+        paymentInformationApiClient.getPaymentInformation('', 'commerceCaseId', 'checkoutId', 'paymentInformationId'),
+      ).rejects.toThrowError('Merchant ID is required');
+      await expect(() =>
+        paymentInformationApiClient.getPaymentInformation('merchantId', '', 'checkoutId', 'paymentInformationId'),
+      ).rejects.toThrowError('Commerce Case ID is required');
+      await expect(() =>
+        paymentInformationApiClient.getPaymentInformation('merchantId', 'commerceCaseId', '', 'paymentInformationId'),
+      ).rejects.toThrowError('Checkout ID is required');
+      await expect(() =>
+        paymentInformationApiClient.getPaymentInformation('merchantId', 'commerceCaseId', 'checkoutId', ''),
+      ).rejects.toThrowError('Payment Information ID is required');
+    });
+  });
+});

--- a/src/endpoints/PaymentInformationApiClient.test.ts
+++ b/src/endpoints/PaymentInformationApiClient.test.ts
@@ -2,23 +2,11 @@ import fetch from 'node-fetch';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { CommunicatorConfiguration } from '../CommunicatorConfiguration.js';
 import {
-  CancellationReason,
   PaymentChannel,
   PaymentType,
-  StatusValue,
-  type CancelPaymentRequest,
-  type CancelPaymentResponse,
-  type CapturePaymentRequest,
-  type CapturePaymentResponse,
-  type CompletePaymentRequest,
-  type CompletePaymentResponse,
-  type CreatePaymentResponse,
   type ErrorResponse,
-  type PaymentExecutionRequest,
   type PaymentInformationRequest,
   type PaymentInformationResponse,
-  type RefundPaymentResponse,
-  type RefundRequest,
 } from '../models/index.js';
 import { createResponseMock, createEmptyErrorResponseMock } from '../testutils/mock-response.js';
 import { ApiErrorResponseException } from '../errors/ApiErrorResponseException.js';

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -1,2 +1,5 @@
 export { CheckoutApiClient } from './CheckoutApiClient.js';
 export { CommerceCaseApiClient } from './CommerceCaseApiClient.js';
+export { OrderManagementCheckoutActionsApiClient } from './OrderManagementCheckoutActionsApiClient.js';
+export { PaymentExecutionApiClient } from './PaymentExecutionApiClient.js';
+export { PaymentInformationApiClient } from './PaymentInformationApiClient.js';

--- a/src/models/Address.ts
+++ b/src/models/Address.ts
@@ -36,4 +36,3 @@ export interface Address {
    */
   zip?: string;
 }
-

--- a/src/models/AmountOfMoney.ts
+++ b/src/models/AmountOfMoney.ts
@@ -12,4 +12,3 @@ export interface AmountOfMoney {
    */
   currencyCode: string;
 }
-

--- a/src/models/AuthorizationMode.ts
+++ b/src/models/AuthorizationMode.ts
@@ -11,4 +11,3 @@ export enum AuthorizationMode {
   PRE_AUTHORIZATION = 'PRE_AUTHORIZATION',
   SALE = 'SALE',
 }
-

--- a/src/models/CancelItem.ts
+++ b/src/models/CancelItem.ts
@@ -13,4 +13,3 @@ export interface CancelItem {
    */
   quantity: number;
 }
-

--- a/src/models/CancelRequest.ts
+++ b/src/models/CancelRequest.ts
@@ -1,6 +1,6 @@
-import type { CancelItem } from "./CancelItem.js";
-import type { CancellationReason } from "./CancellationReason.js";
-import type { CancelType } from "./CancelType.js";
+import type { CancelItem } from './CancelItem.js';
+import type { CancellationReason } from './CancellationReason.js';
+import type { CancelType } from './CancelType.js';
 
 /**
  *  @description Request to mark items as of the respective Checkout as cancelled and to automatically reverse the associated

--- a/src/models/CardPaymentMethodSpecificInput.ts
+++ b/src/models/CardPaymentMethodSpecificInput.ts
@@ -1,10 +1,10 @@
-import type { AuthorizationMode } from "./AuthorizationMode.js";
-import type { CardInfo } from "./CardInfo.js";
-import type { CardOnFileRecurringFrequency } from "./CardOnFileRecurringFrequency.js";
-import type { CardRecurrenceDetails } from "./CardRecurrenceDetails.js";
-import type { TransactionChannel } from "./TransactionChannel.js";
-import type { UnscheduledCardOnFileRequestor } from "./UnscheduledCardOnFileRequestor.js";
-import type { UnscheduledCardOnFileSequenceIndicator } from "./UnscheduledCardOnFileSequenceIndicator.js";
+import type { AuthorizationMode } from './AuthorizationMode.js';
+import type { CardInfo } from './CardInfo.js';
+import type { CardOnFileRecurringFrequency } from './CardOnFileRecurringFrequency.js';
+import type { CardRecurrenceDetails } from './CardRecurrenceDetails.js';
+import type { TransactionChannel } from './TransactionChannel.js';
+import type { UnscheduledCardOnFileRequestor } from './UnscheduledCardOnFileRequestor.js';
+import type { UnscheduledCardOnFileSequenceIndicator } from './UnscheduledCardOnFileSequenceIndicator.js';
 
 /** @description Object containing the specific input details for card payments.  */
 export interface CardPaymentMethodSpecificInput {

--- a/src/models/Order.ts
+++ b/src/models/Order.ts
@@ -8,7 +8,7 @@ import type { ShoppingCartInput } from './ShoppingCartInput.js';
 export interface Order {
   amountOfMoney?: AmountOfMoney;
   customer?: Customer;
-  references: References;
+  references?: References;
   shipping?: Shipping;
   shoppingCart?: ShoppingCartInput;
 }

--- a/src/models/PaymentStatus.ts
+++ b/src/models/PaymentStatus.ts
@@ -1,5 +1,5 @@
 /**
- * @description 
+ * @description
  *     - WAITING_FOR_PAYMENT - There does not yet exist a PaymentExecution nor a PaymentInformation for this
  *     Checkout.
  *     - PAYMENT_NOT_COMPLETED - There exists a PaymentExecution or a PaymentInformation for this Checkout, but all

--- a/src/models/ThreeDSecureResults.ts
+++ b/src/models/ThreeDSecureResults.ts
@@ -1,4 +1,4 @@
-import type { AppliedExemption } from "./AppliedExemption.js";
+import type { AppliedExemption } from './AppliedExemption.js';
 
 /** @description 3D Secure results object */
 export interface ThreeDSecureResults {


### PR DESCRIPTION
- **feat(order-model): references could be empty when send as response**
- **tests(payment-execution-client): check behavior of endpoints**
- **chore: await expect.rejects calls**
- **test(payment-information-client): check behavior of endpoints**
- **test(order-management-client): check behavior of endpoints**
- **feat(api-clients): add client for payment execution, payment information and order management**
